### PR TITLE
fix image link in customer-support-agent readme

### DIFF
--- a/customer-support-agent/README.md
+++ b/customer-support-agent/README.md
@@ -53,7 +53,7 @@ Follow these steps to obtain your AWS credentials:
 4. Click "Create user" and follow the prompts to create a new user
    ![Add User](tutorial/create-user.png)
 5. On the Set Permission page, select the "Attach policies directly" policy
-   ![Attach Policy](tutorial/aws-attach-policy.png)
+   ![Attach Policy](tutorial/attach.png)
 5. On the permissions page, use the "AmazonBedrockFullAccess" policy
    ![Attach Policy](tutorial/bedrock.png)
 6. Review and create the user


### PR DESCRIPTION
Before:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/ac46986e-0e5e-43e4-8002-440ca5fc0f36">

After:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/62216350-d383-4f26-bf0c-b19bb9ad6203">
