### PR TITLE
Add zod dependency

### DIFF
--- a/customer-support-agent/package.json
+++ b/customer-support-agent/package.json
@@ -39,7 +39,8 @@
     "rehype-highlight": "^7.0.0",
     "rehype-raw": "^7.0.0",
     "tailwind-merge": "^2.4.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
This PR adds the 'zod' package as a dependency to resolve the TypeScript error:
"Cannot find module 'zod' or its corresponding type declarations."

## Changes
- Added 'zod' to package.json dependencies

## Testing
- [ ] Run `npm install` or `yarn install` to update dependencies
- [ ] Verify that the TypeScript error is resolved
- [ ] Run existing tests to ensure no regressions

## Additional Notes
After merging this PR, developers should run `npm install` or `yarn install` to update their local dependencies.