### PR TITLE
Specify AWS_REGION in readme.md for bedrock

### DIFF
--- a/computer-use-demo/README.md
+++ b/computer-use-demo/README.md
@@ -58,6 +58,7 @@ export AWS_PROFILE=<your_aws_profile>
 docker run \
     -e API_PROVIDER=bedrock \
     -e AWS_PROFILE=$AWS_PROFILE \
+    -e AWS_REGION=us-west-2 \
     -v $HOME/.aws/credentials:/home/computeruse/.aws/credentials \
     -v $HOME/.anthropic:/home/computeruse/.anthropic \
     -p 5900:5900 \
@@ -80,6 +81,7 @@ docker run \
     -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
+    -e AWS_REGION=us-west-2 \
     -v $HOME/.anthropic:/home/computeruse/.anthropic \
     -p 5900:5900 \
     -p 8501:8501 \


### PR DESCRIPTION
Sonnet 3.5 v2 is only deployed in us-west-2; this adds the right `AWS_REGION` to the demo code so that people don't try to send requests to the wrong region by mistake.