### PR TITLE
Check for python less than 3.12

### DIFF
--- a/computer-use-demo/setup.sh
+++ b/computer-use-demo/setup.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+PYTHON_MINOR_VERSION=$(python3 --version | awk -F. '{print $2}')
+
+if [ "$PYTHON_MINOR_VERSION" -gt 12 ]; then
+    echo "Python version 3.$PYTHON_MINOR_VERSION detected. Python 3.12 or lower is required for setup to complete."
+    echo "If you have multiple versions of Python installed, you can set the correct one by adjusting setup.sh to use a specific version, for example:"
+    echo "'python3 -m venv .venv' -> 'python3.12 -m venv .venv'"
+    exit 1
+fi
+
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip


### PR DESCRIPTION
solution for #58 where we check for python minor version of 12 or below prior to running the rest of setup