### PR TITLE
[computer use] replace spaces in api_key when starting loop

### DIFF
--- a/computer-use-demo/computer_use_demo/streamlit.py
+++ b/computer-use-demo/computer_use_demo/streamlit.py
@@ -224,7 +224,7 @@ async def main():
                     tab=http_logs,
                     response_state=st.session_state.responses,
                 ),
-                api_key=st.session_state.api_key,
+                api_key=st.session_state.api_key.replace(" ", ""),
                 only_n_most_recent_images=st.session_state.only_n_most_recent_images,
             )
 


### PR DESCRIPTION
this addresses #85.

it would seem that if multiple users have already encountered this, maybe the propensity to copy-paste with a trailing space is common enough to address.

maybe not the most graceful solution, just replaces all spaces when the `sampling_loop` begins.

prior to the fix, here's the error when i use an API key with a trailing space:

<img width="355" alt="image" src="https://github.com/user-attachments/assets/20402a23-7996-4923-af71-c8fb785c61a3">

after the fix, no problem, even with a trailing space:

<img width="355" alt="image" src="https://github.com/user-attachments/assets/b7eb32ef-c94c-4794-812f-8af85953e424">
