### PR TITLE
[computer use] add firefox extension to hide cookie warnings

### DIFF
--- a/computer-use-demo/Dockerfile
+++ b/computer-use-demo/Dockerfile
@@ -57,6 +57,11 @@ RUN git clone --branch v1.5.0 https://github.com/novnc/noVNC.git /opt/noVNC && \
     git clone --branch v0.12.0 https://github.com/novnc/websockify /opt/noVNC/utils/websockify && \
     ln -s /opt/noVNC/vnc.html /opt/noVNC/index.html
 
+# Install the 'I still don't care about cookies' extension
+RUN curl -L -o /usr/lib/firefox-esr/browser/extensions/jid1-KKzOGWgsW3Ao4Q@jetpack.xpi \
+    "https://addons.mozilla.org/firefox/downloads/latest/istilldontcareaboutcookies/addon-920220-latest.xpi"
+RUN echo '{ "policies": { "Extensions": { "Install": [ "file:///usr/lib/firefox-esr/browser/extensions/jid1-KKzOGWgsW3Ao4Q@jetpack.xpi" ] } } }' > /usr/lib/firefox-esr/distribution/policies.json
+
 # setup user
 ENV USERNAME=computeruse
 ENV HOME=/home/$USERNAME


### PR DESCRIPTION
This PR adds the Firefox extension [I still don't care about cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies) to the virtual environment. The extension helps the agent navigating through the internet by hiding most cookie warnings.

It is enabled for the user by default:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/be1cb647-022b-4901-bc7f-61edcc1cd30d">

