### PR TITLE
fix: Add y-axis label support to chart rendering

### DIFF
--- a/financial-data-analyst/app/api/finance/route.ts
+++ b/financial-data-analyst/app/api/finance/route.ts
@@ -73,6 +73,7 @@ const tools: ToolSchema[] = [
             footer: { type: "string" as const },
             totalLabel: { type: "string" as const },
             xAxisKey: { type: "string" as const },
+            yAxisKey: { type: "string" as const },
           },
           required: ["title", "description"],
         },
@@ -270,6 +271,7 @@ For Time-Series (Line/Bar/Area):
   ],
   config: {
     xAxisKey: "period",
+    yAxisKey: "sales",
     title: "Quarterly Revenue",
     description: "Revenue growth over time"
   },
@@ -286,6 +288,7 @@ For Comparisons (MultiBar):
   ],
   config: {
     xAxisKey: "category",
+    yAxisKey: "sales",
     title: "Product Performance",
     description: "Sales vs Costs by Product"
   },

--- a/financial-data-analyst/components/ChartRenderer.tsx
+++ b/financial-data-analyst/components/ChartRenderer.tsx
@@ -22,6 +22,7 @@ import {
   Pie,
   PieChart,
   XAxis,
+  YAxis
 } from "recharts";
 import {
   ChartContainer,
@@ -48,6 +49,17 @@ function BarChartComponent({ data }: { data: ChartData }) {
               tickLine={false}
               tickMargin={10}
               axisLine={false}
+              tickFormatter={(value) => {
+                return value.length > 20
+                  ? `${value.substring(0, 17)}...`
+                  : value;
+              }}
+            />
+            <YAxis
+              dataKey={data.config.yAxisKey}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
               tickFormatter={(value) => {
                 return value.length > 20
                   ? `${value.substring(0, 17)}...`
@@ -104,6 +116,17 @@ function MultiBarChartComponent({ data }: { data: ChartData }) {
               tickLine={false}
               tickMargin={10}
               axisLine={false}
+              tickFormatter={(value) => {
+                return value.length > 20
+                  ? `${value.substring(0, 17)}...`
+                  : value;
+              }}
+            />
+            <YAxis
+              dataKey={data.config.yAxisKey}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
               tickFormatter={(value) => {
                 return value.length > 20
                   ? `${value.substring(0, 17)}...`
@@ -167,6 +190,17 @@ function LineChartComponent({ data }: { data: ChartData }) {
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey={data.config.xAxisKey}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tickFormatter={(value) => {
+                return value.length > 20
+                  ? `${value.substring(0, 17)}...`
+                  : value;
+              }}
+            />
+            <YAxis
+              dataKey={data.config.yAxisKey}
               tickLine={false}
               axisLine={false}
               tickMargin={8}
@@ -333,6 +367,17 @@ function AreaChartComponent({
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey={data.config.xAxisKey}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tickFormatter={(value) => {
+                return value.length > 20
+                  ? `${value.substring(0, 17)}...`
+                  : value;
+              }}
+            />
+            <YAxis
+              dataKey={data.config.yAxisKey}
               tickLine={false}
               axisLine={false}
               tickMargin={8}

--- a/financial-data-analyst/types/chart.ts
+++ b/financial-data-analyst/types/chart.ts
@@ -19,6 +19,7 @@ export interface ChartData {
     footer?: string;
     totalLabel?: string;
     xAxisKey?: string;
+    yAxisKey?: string;
   };
   data: Array<Record<string, any>>;
   chartConfig: ChartConfig;


### PR DESCRIPTION
### Anthropic Claude homepage showcases y-axis support on charts - yet the quickstart doesn't have y-axis support. This fixes that - Add y-axis label support for improved chart readability as the 

<img width="579" alt="image" src="https://github.com/user-attachments/assets/adf10ef9-16c8-4268-8913-0d3ad3fe9f1b">

#### Overview:
This PR introduces y-axis label support to the charting library. Previously, users could view data values by hovering over items like the line, but there was no y-axis label to provide immediate context. This caused confusion, particularly when comparing multiple data points.

#### Key Changes:
- Added y-axis label functionality for all relevant chart types.
- Ensured that the labels dynamically adjust based on the scale and chart data.
- Hovering over data points still displays values for detailed examination, but now with corresponding y-axis context.

#### Why this is important:
Charts with unlabeled axes can mislead users or make interpretation harder, especially when users aren't familiar with the specific dataset. This update makes charts more intuitive and user-friendly by ensuring all axes are clearly labeled. 

