### PR TITLE
remove redundant `build-essential` dep installation in computer-use dockerfile

### DIFF
--- a/computer-use-demo/Dockerfile
+++ b/computer-use-demo/Dockerfile
@@ -6,7 +6,6 @@ ENV DEBIAN_PRIORITY=high
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install \
-    build-essential \
     # UI Requirements
     xvfb \
     xterm \


### PR DESCRIPTION
The `build-essential` dependency is listed twice in the computer-use dockerfile. This is mostly a cosmetic fix since duplicate deps shouldn't create any issues. 