### PR TITLE
[computer-use] Correct prompt caching for tools

### DIFF
--- a/computer-use-demo/computer_use_demo/loop.py
+++ b/computer-use-demo/computer_use_demo/loop.py
@@ -134,7 +134,7 @@ async def sampling_loop(
                 messages=messages,
                 model=model,
                 system=[system],
-                tools=tool_collection.to_params(),
+                tools=tool_collection.to_params(enable_prompt_caching),
                 betas=betas,
             )
         except (APIStatusError, APIResponseValidationError) as e:
@@ -242,11 +242,12 @@ def _inject_prompt_caching(
     messages: list[BetaMessageParam],
 ):
     """
-    Set cache breakpoints for the 3 most recent turns
-    one cache breakpoint is left for tools/system prompt, to be shared across sessions
+    Set cache breakpoints for the 2 most recent turns
+    one cache breakpoint is left for system prompt, to be shared across sessions
+    one cache breakpoint is left for system prompt, to be shared across sessions
     """
 
-    breakpoints_remaining = 3
+    breakpoints_remaining = 2
     for message in reversed(messages):
         if message["role"] == "user" and isinstance(
             content := message["content"], list

--- a/computer-use-demo/computer_use_demo/tools/collection.py
+++ b/computer-use-demo/computer_use_demo/tools/collection.py
@@ -21,8 +21,12 @@ class ToolCollection:
 
     def to_params(
         self,
+        enable_caching:bool = False
     ) -> list[BetaToolUnionParam]:
-        return [tool.to_params() for tool in self.tools]
+        tools = [tool.to_params() for tool in self.tools]
+        if enable_caching:
+            tools[-1]["cache_control"] = {"type": "ephemeral"}
+        return tools
 
     async def run(self, *, name: str, tool_input: dict[str, Any]) -> ToolResult:
         tool = self.tool_map.get(name)


### PR DESCRIPTION
Following the official prompt caching documentation the current way computer use uses prompt caching does not include the tools - only the system prompt. This patch fixes this. 