### PR TITLE
fix bedrock inference region

### DIFF
--- a/computer-use-demo/computer_use_demo/loop.py
+++ b/computer-use-demo/computer_use_demo/loop.py
@@ -43,7 +43,7 @@ class APIProvider(StrEnum):
 
 PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
     APIProvider.ANTHROPIC: "claude-3-5-sonnet-20241022",
-    APIProvider.BEDROCK: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    APIProvider.BEDROCK: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     APIProvider.VERTEX: "claude-3-5-sonnet-v2@20241022",
 }
 


### PR DESCRIPTION
The Claude 3.5 Sonnet v2 model doesn't work unless I SSH into the container and update this line to the inference profile ID copied from bedrock in AWS console