### PR TITLE
fix: respect user-selected tool version in computer use demo

### DIFF
--- a/computer-use-demo/computer_use_demo/streamlit.py
+++ b/computer-use-demo/computer_use_demo/streamlit.py
@@ -141,7 +141,13 @@ def _reset_model_conf():
         if "3-7" in st.session_state.model
         else MODEL_TO_MODEL_CONF.get(st.session_state.model, SONNET_3_5_NEW)
     )
-    st.session_state.tool_version = model_conf.tool_version
+
+    # If we're in radio selection mode, use the selected tool version
+    if hasattr(st.session_state, "tool_versions"):
+        st.session_state.tool_version = st.session_state.tool_versions
+    else:
+        st.session_state.tool_version = model_conf.tool_version
+
     st.session_state.has_thinking = model_conf.has_thinking
     st.session_state.output_tokens = model_conf.default_output_tokens
     st.session_state.max_output_tokens = model_conf.max_output_tokens
@@ -210,6 +216,9 @@ async def main():
             key="tool_versions",
             options=versions,
             index=versions.index(st.session_state.tool_version),
+            on_change=lambda: setattr(
+                st.session_state, "tool_version", st.session_state.tool_versions
+            ),
         )
 
         st.number_input("Max Output Tokens", key="output_tokens", step=1)
@@ -309,7 +318,7 @@ async def main():
                 ),
                 api_key=st.session_state.api_key,
                 only_n_most_recent_images=st.session_state.only_n_most_recent_images,
-                tool_version=st.session_state.tool_version,
+                tool_version=st.session_state.tool_versions,
                 max_tokens=st.session_state.output_tokens,
                 thinking_budget=st.session_state.thinking_budget
                 if st.session_state.thinking


### PR DESCRIPTION
Ensure the tool version selected via the radio button is properly used in API calls instead of defaulting to the model config value. This allows custom model strings to specify the computer use beta version they require.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Describe the changes you've made -->

## Quickstart
- [x] Computer Use Demo
- [ ] Customer Support Agent
- [ ] Financial Data Analyst
- [ ] N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing
<!-- Describe the testing you've done -->
- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Verified in development environment

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional context or notes about the changes -->