### PR TITLE
use correct beta header for new computer use

### DIFF
--- a/computer-use-demo/computer_use_demo/tools/groups.py
+++ b/computer-use-demo/computer_use_demo/tools/groups.py
@@ -35,7 +35,7 @@ TOOL_GROUPS: list[ToolGroup] = [
     ToolGroup(
         version="computer_use_20250429",
         tools=[ComputerTool20250124, EditTool20250429, BashTool20250124],
-        beta_flag="computer-use-2025-04-29",
+        beta_flag="computer-use-2025-01-24",
     ),
 ]
 


### PR DESCRIPTION
`EditTool20250429` doesn't require a new beta header!

`computer-use-2025-01-24` continues to be correct, only required for `ComputerTool20250124`